### PR TITLE
check for max regen and max consumption

### DIFF
--- a/app/src/main/java/g4rb4g3/at/abrptransmitter/ABetterRoutePlanner.java
+++ b/app/src/main/java/g4rb4g3/at/abrptransmitter/ABetterRoutePlanner.java
@@ -178,7 +178,7 @@ public class ABetterRoutePlanner {
       return;
     }
     float average = Average.getAverageConsumption();
-    if (average > -1) {
+    if (average > -100 && average < 100) { // regen and consumption check
       jTlmObj.put(ABETTERROUTEPLANNER_JSON_POWER, average);
     }
     jTlmObj.put(ABETTERROUTEPLANNER_JSON_TIME, System.currentTimeMillis() / 1000);


### PR DESCRIPTION
this should avoid too large wrongly calculated consumption values. will try to find out the problem with the calculation later on, but to me it looks like everything is correct there. so for people to get correct results we should add this check for now.