### PR TITLE
don't send telemetry if it is invalid

### DIFF
--- a/app/src/main/java/g4rb4g3/at/abrptransmitter/service/AbrpTransmitterService.java
+++ b/app/src/main/java/g4rb4g3/at/abrptransmitter/service/AbrpTransmitterService.java
@@ -260,7 +260,9 @@ public class AbrpTransmitterService extends Service {
       try {
         sLog.debug("AbrpUpdater, updating telemetry object");
         mJTlmObj.put(ABETTERROUTEPLANNER_JSON_TIME, System.currentTimeMillis() / 1000);
-        mJTlmObj.put(ABETTERROUTEPLANNER_JSON_SOC, mGreenCarManager.getBatteryChargePersent());
+        int soc = mGreenCarManager.getBatteryChargePersent();
+        if (soc == 0) return;
+        mJTlmObj.put(ABETTERROUTEPLANNER_JSON_SOC, soc);
         mJTlmObj.put(ABETTERROUTEPLANNER_JSON_SPEED, mCarInfoManager.getCarSpeed());
         mJTlmObj.put(ABETTERROUTEPLANNER_JSON_CHARGING, mGreenCarManager.getChargeStatus());
         mJTlmObj.put(ABETTERROUTEPLANNER_JSON_POWER, mAverageCollector.getAverage());


### PR DESCRIPTION
Manchmal wird SoC als 0 und Temp als 87°C übertragen, ob man Temp extra checken sollte weiß ich nicht, aber SoC == 0 ist sehr unwarscheinlich und sollte zumindest einen falschen SoC beheben. Meine Vermutung ist, dass die falsche Temperatur dann auch nicht gesendet wird.